### PR TITLE
Fix two exponential regex backtracking vulnerabilities

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -45,8 +45,7 @@ var reLinkTitle = new RegExp(
         '|' +
         '\\((' + ESCAPED_CHAR + '|[^)\\x00])*\\))');
 
-var reLinkDestinationBraces = new RegExp(
-    '^(?:[<](?:[^<>\\n\\\\\\x00]' + '|' + ESCAPED_CHAR + '|' + '\\\\)*[>])');
+var reLinkDestinationBraces = /^(?:<(?:[^<>\n\\\x00]|\\.)*>)/;
 
 var reEscapable = new RegExp('^' + ESCAPABLE);
 
@@ -78,8 +77,7 @@ var reInitialSpace = /^ */;
 
 var reSpaceAtEndOfLine = /^ *(?:\n|$)/;
 
-var reLinkLabel = new RegExp('^\\[(?:[^\\\\\\[\\]]|' + ESCAPED_CHAR +
-  '|\\\\){0,1000}\\]');
+var reLinkLabel = /^\[(?:[^\\\[\]]|\\.){0,1000}\]/;
 
 // Matches a string of non-special characters.
 var reMain = /^[^\n`\[\]\\!<&*_'"]+/m;
@@ -524,9 +522,7 @@ var parseLinkDestination = function() {
 // Attempt to parse a link label, returning number of characters parsed.
 var parseLinkLabel = function() {
     var m = this.match(reLinkLabel);
-    // Note:  our regex will allow something of form [..\];
-    // we disallow it here rather than using lookahead in the regex:
-    if (m === null || m.length > 1001 || /[^\\]\\\]$/.exec(m)) {
+    if (m === null || m.length > 1001) {
         return 0;
     } else {
         return m.length;


### PR DESCRIPTION
`ESCAPED_CHAR` already matches `\\`, so matching it again in another alternative was just causing an exponential complexity explosion.

Fixes #157.