### PR TITLE
dingus: add dependency version requirements

### DIFF
--- a/dingus/.gitignore
+++ b/dingus/.gitignore
@@ -3,4 +3,5 @@
 !dingus.js
 !index.html
 !preview.html
+!bower.json
 !Makefile

--- a/dingus/bower.json
+++ b/dingus/bower.json
@@ -1,0 +1,10 @@
+{
+  "name": "commonmark-dingus",
+  "description": "CommonMark dingus",
+  "private": true,
+  "dependencies": {
+    "bootstrap": "^3.3.7",
+    "jquery": "^3.1.1",
+    "lodash": "^4.17.2"
+  }
+}

--- a/dingus/bower.json
+++ b/dingus/bower.json
@@ -5,6 +5,6 @@
   "dependencies": {
     "bootstrap": "^3.3.7",
     "jquery": "^3.1.1",
-    "lodash": "^4.17.2"
+    "lodash": "^4.17.11"
   }
 }


### PR DESCRIPTION
Dingus was rendering incorrectly with Bootstrap 4. Added a bower.json
which requires Bootstrap, jQuery and Lodash with major version equal
to what's currently live. Likewise the minimum patch version.