### PR TITLE
Avoid numerical conversion for file names in argv

### DIFF
--- a/bin/commonmark
+++ b/bin/commonmark
@@ -10,7 +10,7 @@ var args = process.argv.slice(2);
 var argv = parseArgs(args,
   {boolean: ["ast", "xml", "time", "smart",
              "safe", "sourcepos", "help", "version"],
-   string: ["to", "t"],
+   string: ["_", "to", "t"],
    unknown: function(o) {
      if (/^-/.test(o)) {
       process.stderr.write("Unknown option " + o + "\n");


### PR DESCRIPTION
If you run this:

```
./commonmark.js 1
```

Minimist converts 1 to a number, then fs.readFileSync(1, 'utf8') will
actually read FD 1 (i.e. stdin) instead of a file as one would expect.

Related issues:

https://github.com/substack/minimist/issues/36
https://github.com/substack/minimist/issues/32