### PR TITLE
Sync .editorconfig indent_size to actual

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ insert_final_newline = true
 [*.js]
 trim_trailing_whitespace = true
 indent_style = space
-indent_size = 2
+indent_size = 4
 
 [Makefile]
 trim_trailing_whitespace = true


### PR DESCRIPTION
All of the JS source uses an indent of 4, but the .editorconfig has it as 2. 