### PR TITLE
Don't decode url before encoding it again

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -56,7 +56,7 @@ var unescapeString = function(s) {
 
 var normalizeURI = function(uri) {
     try {
-        return encode(decode(uri));
+        return encode(uri);
     }
     catch(err) {
         return uri;

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var encode = require('mdurl/encode');
-var decode = require('mdurl/decode');
 
 var C_BACKSLASH = 92;
 

--- a/test/regression.txt
+++ b/test/regression.txt
@@ -122,7 +122,15 @@ Double-encoding.
 ```````````````````````````````` example
 [XSS](javascript&amp;colon;alert%28&#039;XSS&#039;%29)
 .
-<p><a href="javascript&amp;colon;alert('XSS')">XSS</a></p>
+<p><a href="javascript&amp;colon;alert%28'XSS'%29">XSS</a></p>
+````````````````````````````````
+
+PR #179
+
+```````````````````````````````` example
+[link](https://www.example.com/home/%25batty)
+.
+<p><a href="https://www.example.com/home/%25batty">link</a></p>
 ````````````````````````````````
 
 Issue commonamrk#517 - script, pre, style close tag without


### PR DESCRIPTION
Decoding before encoding leads to invalid urls. Here's an example:

Let's assume this markdown:

```md
[link](https://www.example.com/home/%25batty)
```

> Note: `%25` is the code for the `%` character

This results in:

```
var dest1 = decode("https://www.example.com/home/%25batty")
//dest1 = https://www.example.com/home/%batty

var dest2 = encode(dest1)
// dest2 = https://www.example.com/home/%batty 
```

since `%ba` is a potential percentage-encoded hex code, mdurl's encode doesn't change it. resulting in an invalid link.

As far as I'm aware, just doing `encode(uri)` is doing the desired thing. for all kinds of uris