### PR TITLE
Fixed invalid package.json dependency entries.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "test": "node ./test/test.js"
   },
   "dependencies": {
-    "entities": "~ 1.1.1",
-    "mdurl": "~ 1.0.1",
+    "entities": "~1.1.1",
+    "mdurl": "~1.0.1",
     "string.prototype.repeat": "^0.2.0",
-    "minimist": "~ 1.2.0"
+    "minimist": "~1.2.0"
   },
   "directories": {
     "lib": "./lib"


### PR DESCRIPTION
Removed space chars that were resulting in invalid dependency declarations, which were masked by the fact that Markdown-it's package.json happened to install these dependencies correctly.

`npm ls` will confirm the problem, and will confirm it's gone after applying the patch. 