### PR TITLE
Remove superfluous push to delimiter stack in handleDelim

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -329,7 +329,7 @@ var handleDelim = function(cc, block) {
     // Add entry to stack for this opener
     if (
         (res.can_open || res.can_close) &&
-        (this.options.smart || cc !== C_SINGLEQUOTE || cc !== C_DOUBLEQUOTE)
+        (this.options.smart || (cc !== C_SINGLEQUOTE && cc !== C_DOUBLEQUOTE))
     ) {
         this.delimiters = {
             cc: cc,


### PR DESCRIPTION
A clause in the condition gating whether to add a parsed
`'` or `"` to the delimiter stack *always* evaluated to TRUE.
What is clearly a typo happened to not break any tests
and *probably* only wasted a bit of memory and CPU.

This commit reflects what I believe to be the original
intention: Only add `'` and `"` if smart quotes is enabled.