### PR TITLE
Configure GitHub Actions to test on Node.js 14 and 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         versions:
+          - node: '15.x
+          - node: '14.x'
           - node: '13.x'
           - node: '12.x'
           - node: '11.x'


### PR DESCRIPTION
This tiny PR changes the GitHub Actions configuration for continuous integration to test on Node.js version 14.x, which is the latest long-term-support major version, and version 15.x, the "current" major version.