### PR TITLE
Update "Basic Usage" comment in lib/index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,9 +6,9 @@
 
 // Basic usage:
 //
-// var commonmark = require('commonmark');
-// var parser = new commonmark.Parser();
-// var renderer = new commonmark.HtmlRenderer();
+// import { Parser, HtmlRenderer } from 'commonmark';
+// var parser = new Parser();
+// var renderer = new HtmlRenderer();
 // console.log(renderer.render(parser.parse('Hello *world*')));
 
 export { default as Node } from "./node.js";


### PR DESCRIPTION
This small PR updates the "Basic Usage" example in a comment in `lib/index.js` to correctly reflect how to `import` from an ES Module.

Note that as converted to ES Modules, `commonmark` does _not_ export anything by default.  Users needs to do `import { Parser, HtmlRendered} from 'commonmark'` or the like, or alternatively `import * as commonmark from 'commonmark'`. Plain old `import commonmark from 'commonmark'` won't work.

This PR does _not_ fix errors loading the package under Node.js.  More on that shortly.