### PR TITLE
Cure ES Module Madness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,11 @@ test: $(SPEC)
 	npm test
 
 bench:
-	node -r esm bench/bench.js ${BENCHINP}
+	node bench/bench.js ${BENCHINP}
 
 bench-detailed:
 	sudo renice -10 $$$$; \
-	for x in bench/samples/*.md; do echo $$x; node -r esm bench/bench.js $$x; done | \
+	for x in bench/samples/*.md; do echo $$x; node bench/bench.js $$x; done | \
 	awk -f bench/format_benchmarks.awk
 
 npm:

--- a/bench/package.json
+++ b/bench/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/bin/commonmark
+++ b/bin/commonmark
@@ -3,7 +3,7 @@
 
 var util = require('util');
 var fs = require('fs');
-var commonmark = require('../lib/index.js');
+var commonmark = require('../');
 var version = require('../package.json').version;
 var parseArgs = require('minimist');
 var args = process.argv.slice(2);

--- a/bin/commonmark
+++ b/bin/commonmark
@@ -1,13 +1,11 @@
-#!/usr/bin/env -S node -r esm
+#!/usr/bin/env node
 "use strict";
 
-import util from "util";
-import fs from "fs";
-import os from "os";
-import * as commonmark from "../lib/index.js";
+var util = require('util');
+var fs = require('fs');
+var commonmark = require('../lib/index.js');
 var version = require('../package.json').version;
-import parseArgs from "minimist";
-
+var parseArgs = require('minimist');
 var args = process.argv.slice(2);
 var argv = parseArgs(args,
   {boolean: ["ast", "xml", "time", "smart",
@@ -77,16 +75,12 @@ if (format === 'html') {
 }
 
 if (files.length === 0) {
-   if (os.platform() === "win32") {
-     inps.push(fs.readFileSync(0, 'utf-8'));
-   } else {
-     inps.push(fs.readFileSync('/dev/tty', 'utf-8'));
-   }
-} else {
-  for (i = 0; i < files.length; i++) {
-    var file = files[i];
-    inps.push(fs.readFileSync(file, 'utf8'));
-  }
+  files = ['/dev/stdin'];
+}
+
+for (i = 0; i < files.length; i++) {
+  var file = files[i];
+  inps.push(fs.readFileSync(file, 'utf8'));
 }
 
 var inp = inps.join('\n');

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,7 +1,7 @@
 "use strict";
 
 import encode from "mdurl/encode.js";
-import * as entities from "entities";
+import { decodeHTML } from "entities";
 
 var C_BACKSLASH = 92;
 
@@ -58,7 +58,7 @@ var unescapeChar = function(s) {
     if (s.charCodeAt(0) === C_BACKSLASH) {
         return s.charAt(1);
     } else {
-        return entities.decodeHTML(s);
+        return decodeHTML(s);
     }
 };
 

--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -3,7 +3,7 @@
 import Node from "./node.js";
 import * as common from "./common.js";
 import fromCodePoint from "./from-code-point.js";
-import * as entities from "entities";
+import { decodeHTML } from "entities";
 import "string.prototype.repeat"; // Polyfill for String.prototype.repeat
 
 var normalizeURI = common.normalizeURI;
@@ -756,7 +756,7 @@ var removeBracket = function() {
 var parseEntity = function(block) {
     var m;
     if ((m = this.match(reEntityHere))) {
-        block.appendChild(text(entities.decodeHTML(m)));
+        block.appendChild(text(decodeHTML(m)));
         return true;
     } else {
         return false;

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -521,11 +521,6 @@
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true
     },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
-    },
     "espree": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,14 +30,13 @@
   "scripts": {
     "build": "rollup -c",
     "lint": "eslint .",
-    "test": "node -r esm ./test/test"
+    "test": "node ./test/test"
   },
   "dependencies": {
     "entities": "~2.0",
-    "esm": "^3.2.25",
     "mdurl": "~1.0.1",
-    "string.prototype.repeat": "^0.2.0",
-    "minimist": ">=1.2.2"
+    "minimist": ">=1.2.2",
+    "string.prototype.repeat": "^0.2.0"
   },
   "directories": {
     "lib": "./lib"

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
This PR attempts to resolve various issues and errors affecting bin script execution and loading via `import` in Node.js. It doesn't touch the existing conditional-import or `module` bunlder entry point configurations in `package.json` at root.

Overall, the blunt instrument at work here is `package.json` files with `"type":"module"` set. In order to make clear to Node.js what is an old CommonJS module and what is a new ES Module, we have just a few choices:
- Use `.cjs` for CommonJS and `.mjs` for ES Modules. But old versions of Node don't know about this convention.
- Pass flags to Node. But again, only recent versions of Node know the latest flags. And we generally don't control how Node.js is invoked, outside our own tests and other development scripts.
- Set `type` to `"commonjs"` or `"module"` in `package.json`, at package root, in subdirectories, or both. Newer versions of Node will look at the nearest `package.json` and load `.js` files according to the `type` specifier. Cluttering, but effective.

For maximum compatibility and minimum renaming things, I've opted to add `package.json` files in several sudirectories. The `package.json` at root continues to have `"type":"commonjs"`. But that is overridden for `lib`, `test`, and `bench`, which have been rewritten as ES Modules. I did _not_ add such `package.json` files to `dist` or `dingus`. `dist/commonmark.js` _is_ the entry point when folks use `require` to load this package, so it is and should be treated as CommonJS.

As for the bin script, which will always be run by Node.js, and not a browser, I don't see any practical advantages to ES Modules right now. If and when this package drops support for Node.js <= 13, the bin script can be safely rewritten with `import`. But for now, `require` works fine and doesn't cause compat problems.

Preloading the `esm` package via a Node.js flag might work in many cases, but it's not necessary. Downloading and loading `esm` is a kludge for those on old versions of Node.js, and wholly unnecessary for those on 14, 15, or later. As a general matter, I like to keep packages out of the decision making process about whether and how to configure module loading for any module but the one the package offers. That's something that users of the package can decide on and configure for themselves and all their dependencies.

I've included more detailed discussions in commit messages.