### PR TITLE
CommonJS Tests and Benchmarks Again

### DIFF
--- a/bench/bench.js
+++ b/bench/bench.js
@@ -1,11 +1,11 @@
 "use strict";
 
-import benchmark from "benchmark";
-import fs from "fs";
-import * as commonmark from "../lib/index.js";
-import Showdown from "showdown";
-import marked from "marked";
-import _markdownit from "markdown-it";
+var benchmark = require("benchmark");
+var fs = require("fs");
+var commonmark = require("commonmark");
+var Showdown = require("showdown");
+var marked = require("marked");
+var _markdownit = require("markdown-it");
 
 var suite = new benchmark.Suite();
 var markdownit = _markdownit("commonmark");

--- a/bench/package.json
+++ b/bench/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -515,12 +515,22 @@
         "eslint-visitor-keys": "^1.1.0"
       }
     },
+<<<<<<< HEAD
     "eslint-visitor-keys": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true
     },
+||||||| 435f7b8... Use esm for bench and test.
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true
+    },
+=======
+>>>>>>> parent of 435f7b8... Use esm for bench and test.
     "espree": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.1.0.tgz",

--- a/test/package.json
+++ b/test/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}

--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 "use strict";
 
-import fs from "fs";
-import * as commonmark from "../lib/index.js";
+// Using commonjs here so CI can run the test file on older Node.js versions
+var fs = require("fs");
+var commonmark = require("..");
 
 // Home made mini-version of the npm ansi module:
 var escSeq = function(s) {


### PR DESCRIPTION
This PR reverts work porting test and benchmark scripts to ES Modules.

Until we're ready to drop support for Node.js versions with ES Module support, we need to keep the test and benchmark runners in CommonJS, so the old Node.js versions we want to test on can run them.