### PR TITLE
Allow user to specify a function to escape the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,8 @@ Both `HtmlRenderer` and `XmlRenderer` (see below) support these options:
   `vbscript:`, `file:`, and with a few exceptions `data:`) will
   be replaced with empty strings.
 - `softbreak`: specify raw string to be used for a softbreak.
-- `esc`: specify a function to be used to escape strings.  Its
-  first argument is the string to be escaped, the second argument
-  is a boolean indicating whether to preserves entities in that
-  string.
+- `esc`: specify a function to be used to escape strings.  Its 
+  argument is the string.
 
 For example, to make soft breaks render as hard breaks in HTML:
 

--- a/lib/render/html.js
+++ b/lib/render/html.js
@@ -37,6 +37,9 @@ function HtmlRenderer(options) {
     options.softbreak = options.softbreak || "\n";
     // set to "<br />" to make them hard breaks
     // set to " " if you want to ignore line wrapping in source
+    this.esc = options.esc || escapeXml;
+    // escape html with a custom function
+    // else use escapeXml
 
     this.disableTags = 0;
     this.lastOut = "\n";

--- a/lib/render/xml.js
+++ b/lib/render/xml.js
@@ -17,6 +17,10 @@ function XmlRenderer(options) {
 
     this.indentLevel = 0;
     this.indent = "  ";
+    
+    this.esc = options.esc || escapeXml;
+    // escape html with a custom function
+    // else use escapeXml
 
     this.options = options;
 }


### PR DESCRIPTION
README.md says you can specify an `esc` function to customise escaping of the output.

However, this isn't the case. Your `esc` function argument is roundly ignored. I've changed this in the `XML` and `HTML` parsers so it's now taken into account.

The docs used to say the `esc` function takes two parameters, the string and whether it should be escaped, but this is not the case in the codebase, so I've changed the README.md