### PR TITLE
Speed up decoding HTML Entities.

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -1,7 +1,7 @@
 "use strict";
 
 import encode from "mdurl/encode.js";
-import { decodeHTML } from "entities";
+import { decodeEntity } from "html-entities";
 
 var C_BACKSLASH = 92;
 
@@ -58,7 +58,7 @@ var unescapeChar = function(s) {
     if (s.charCodeAt(0) === C_BACKSLASH) {
         return s.charAt(1);
     } else {
-        return decodeHTML(s);
+        return decodeEntity(s);
     }
 };
 

--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -3,7 +3,7 @@
 import Node from "./node.js";
 import * as common from "./common.js";
 import fromCodePoint from "./from-code-point.js";
-import { decodeHTML } from "entities";
+import { decodeEntity } from "html-entities";
 import "string.prototype.repeat"; // Polyfill for String.prototype.repeat
 
 var normalizeURI = common.normalizeURI;
@@ -756,7 +756,7 @@ var removeBracket = function() {
 var parseEntity = function(block) {
     var m;
     if ((m = this.match(reEntityHere))) {
-        block.appendChild(text(decodeHTML(m)));
+        block.appendChild(text(decodeEntity(m)));
         return true;
     } else {
         return false;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "pretest": "npm run build"
   },
   "dependencies": {
-    "html-entities": "^2.2.0",
+    "html-entities": "^2.3.2",
     "mdurl": "~1.0.1",
     "minimist": ">=1.2.2",
     "string.prototype.repeat": "^0.2.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "pretest": "npm run build"
   },
   "dependencies": {
-    "entities": "~2.0",
+    "html-entities": "^2.2.0",
     "mdurl": "~1.0.1",
     "minimist": ">=1.2.2",
     "string.prototype.repeat": "^0.2.0"


### PR DESCRIPTION
Improve performance by using `decodeEntity()` from `html-entities` when decoding entities.

## Benchmark results

### Before

```sh
$ node bench/bench.js bench/samples/inline-entity.md
commonmark.js x 35,682 ops/sec ±1.52% (87 runs sampled)
showdown.js x 7,871 ops/sec ±4.67% (84 runs sampled)
marked.js x 55,382 ops/sec ±1.05% (96 runs sampled)
markdown-it x 41,105 ops/sec ±20.31% (89 runs sampled)
```

### After

```sh
$ node bench/bench.js bench/samples/inline-entity.md
commonmark.js x 42,870 ops/sec ±5.41% (83 runs sampled)
showdown.js x 8,168 ops/sec ±1.11% (89 runs sampled)
marked.js x 51,986 ops/sec ±4.46% (86 runs sampled)
markdown-it x 47,063 ops/sec ±3.06% (94 runs sampled)
```