### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -520,7 +520,7 @@ var parseLinkTitle = function() {
         return null;
     } else {
         // chop off quotes from title and unescape:
-        return unescapeString(title.substr(1, title.length - 2));
+        return unescapeString(title.slice(1, -1));
     }
 };
 
@@ -567,11 +567,11 @@ var parseLinkDestination = function() {
         if (openparens !== 0) {
             return null;
         }
-        res = this.subject.substr(savepos, this.pos - savepos);
+        res = this.subject.slice(savepos, this.pos);
         return normalizeURI(unescapeString(res));
     } else {
         // chop off surrounding <..>:
-        return normalizeURI(unescapeString(res.substr(1, res.length - 2)));
+        return normalizeURI(unescapeString(res.slice(1, -1)));
     }
 };
 
@@ -856,7 +856,7 @@ var parseReference = function(s, refmap) {
     if (matchChars === 0) {
         return 0;
     } else {
-        rawlabel = this.subject.substr(0, matchChars);
+        rawlabel = this.subject.slice(0, matchChars);
     }
 
     // colon:


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.