### PR TITLE
Track underscore bottom separately mod 3, like asterisk

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -382,7 +382,7 @@ var processEmphasis = function(stack_bottom) {
     var openers_bottom_index;
     var odd_match = false;
 
-    for (var i = 0; i < 8; i++) {
+    for (var i = 0; i < 14; i++) {
         openers_bottom[i] = stack_bottom;
     }
     // find first closer above stack_bottom:
@@ -407,10 +407,11 @@ var processEmphasis = function(stack_bottom) {
                  openers_bottom_index = 1;
                  break;
                case C_UNDERSCORE:
-                 openers_bottom_index = 2;
+                 openers_bottom_index = 2 + (closer.can_open ? 3 : 0)
+                                          + (closer.origdelims % 3);
                  break;
                case C_ASTERISK:
-                 openers_bottom_index = 3 + (closer.can_open ? 3 : 0)
+                 openers_bottom_index = 8 + (closer.can_open ? 3 : 0)
                                           + (closer.origdelims % 3);
                  break;
             }

--- a/test/regression.txt
+++ b/test/regression.txt
@@ -426,3 +426,32 @@ Link reference definitions are blocks when checking list tightness.
 </li>
 </ul>
 ````````````````````````````````
+
+An underscore that is not part of a delimiter should not prevent another
+pair of underscores from forming part of their own.
+```````````````````````````````` example
+__!_!__
+
+__!x!__
+
+**!*!**
+
+---
+
+_*__*_*
+
+_*xx*_*
+
+_*__-_-
+
+_*xx-_-
+.
+<p><strong>!_!</strong></p>
+<p><strong>!x!</strong></p>
+<p><strong>!*!</strong></p>
+<hr />
+<p><em><em>__</em></em>*</p>
+<p><em><em>xx</em></em>*</p>
+<p><em>*__-</em>-</p>
+<p><em>*xx-</em>-</p>
+````````````````````````````````


### PR DESCRIPTION
Fixes #271

The reasoning that a failed delimiter means future delimiters will also fail only applies if the reason they failed was not the multiple-of-three rule. This was already implemented correctly for asterisks, but not for underscore.