### PR TITLE
Remove `string.prototype.repeat` polyfill

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -4,7 +4,6 @@ import Node from "./node.js";
 import * as common from "./common.js";
 import fromCodePoint from "./from-code-point.js";
 import { decodeHTMLStrict } from "entities";
-import "string.prototype.repeat"; // Polyfill for String.prototype.repeat
 
 var normalizeURI = common.normalizeURI;
 var unescapeString = common.unescapeString;

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
   "dependencies": {
     "entities": "~3.0.1",
     "mdurl": "~1.0.1",
-    "minimist": "~1.2.5",
-    "string.prototype.repeat": "^1.0.0"
+    "minimist": "~1.2.5"
   },
   "directories": {
     "lib": "./lib"


### PR DESCRIPTION
Every browser supports `string.prototype.repeat` since 2016 so the polyfill can be removed now.

https://caniuse.com/mdn-javascript_builtins_string_repeat

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat