### PR TITLE
Don't trim non-ASCII whitespace

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -980,7 +980,11 @@ var parseInline = function(block) {
 // Parse string content in block into inline children,
 // using refmap to resolve references.
 var parseInlines = function(block) {
-    this.subject = block._string_content.trim();
+    // trim() removes non-ASCII whitespaces, vertical tab, form feed and so on.
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim#return_value
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#white_space
+    // Removes only ASCII tab and space.
+    this.subject = block._string_content.replace(/^[\t \r\n]+|[\t \r\n]+$/g, "")
     this.pos = 0;
     this.delimiters = null;
     this.brackets = null;

--- a/test/regression.txt
+++ b/test/regression.txt
@@ -518,3 +518,31 @@ foo <!-- test --> more -->
 <p>foo <!-----></p>
 <p>foo <!-- test --> more --&gt;</p>
 ````````````````````````````````
+
+#261
+```````````````````````````````` example
+Vertical Tab
+
+Form Feed
+
+ NBSP (U+00A0) NBSP 
+
+ Em Space (U+2003) Em Space 
+
+ Line Separator (U+2028) Line Separator 
+
+ Paragraph Separator (U+2029) Paragraph Separator 
+
+　全角スペース (U+3000) 全形空白　
+
+﻿ZWNBSP (U+FEFF) ZWNBSP﻿
+.
+<p>Vertical Tab</p>
+<p>Form Feed</p>
+<p> NBSP (U+00A0) NBSP </p>
+<p> Em Space (U+2003) Em Space </p>
+<p> Line Separator (U+2028) Line Separator </p>
+<p> Paragraph Separator (U+2029) Paragraph Separator </p>
+<p>　全角スペース (U+3000) 全形空白　</p>
+<p>﻿ZWNBSP (U+FEFF) ZWNBSP﻿</p>
+````````````````````````````````


### PR DESCRIPTION
Fixes #261 

`.trim()` removes non-ascii Unicode white spaces as well.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim


```
PS D:\cmark\out\install\x64-Debug\bin> .\cmark.exe
　全角スペース (U+3000) 全形空白　

 Em Space (U+2003) Em Space 

 NBSP (U+00A0) NBSP
^Z
<p>　全角スペース (U+3000) 全形空白　</p>
<p>?Em Space (U+2003) Em Space?</p>
<p>NBSP (U+00A0) NBSP</p>
```

~~cmark removes NBSP, but is this an expected behavior?~~
(`?` means U+2003 can't be converted to Shift_JIS, which is the OEM encoding in Japanese Windows.)