### PR TITLE
Don't use regex that can be slow

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -980,17 +980,38 @@ var parseInline = function(block) {
 // Parse string content in block into inline children,
 // using refmap to resolve references.
 var parseInlines = function(block) {
-    // trim() removes non-ASCII whitespaces, vertical tab, form feed and so on.
+    // String.protoype.trim() removes non-ASCII whitespaces, vertical tab, form feed and so on.
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim#return_value
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#white_space
     // Removes only ASCII tab and space.
-    this.subject = block._string_content.replace(/^[\t \r\n]+|[\t \r\n]+$/g, "")
+    this.subject = trim(block._string_content)
     this.pos = 0;
     this.delimiters = null;
     this.brackets = null;
     while (this.parseInline(block)) {}
     block._string_content = null; // allow raw string to be garbage collected
     this.processEmphasis(null);
+
+    function trim(str) {
+        var start = 0;
+        for(; start < str.length; start++) {
+            if (!isSpace(str.charCodeAt(start))) {
+                break;
+            }
+        }
+        var end = str.length - 1;
+        for(; end >= start; end--) {
+            if (!isSpace(str.charCodeAt(end))) {
+                break;
+            }
+        }
+        return str.slice(start, end + 1);
+
+        function isSpace(c) {
+            // U+0020 = space, U+0009 = tab, U+000A = LF, U+000D = CR
+            return c === 0x20 || c === 9 || c === 0xa || c === 0xd;
+        }
+    }
 };
 
 // The InlineParser object.


### PR DESCRIPTION
The regex introduced in #289 can be slow.
For example,

```js
('a' + ' '.repeat(65534) + 'a').replace(/^[\t \r\n]+|[\t \r\n]+$/g,"").length
```

takes a long time to be done. (a few seconds)

```js
/^[\t \r\n]+(?![\t \r\n])|(?<![\t \r\n])[\t \r\n]+$/g,
```

fixes the problem, but the naive implementation of this PR seems to be faster than it when the number of trimmed spaces are not many according to my private bench by [mitata](https://github.com/evanwashere/mitata).
Using `charCodeAt` is fastest but reduces the explainability due to the raw code point number literals (e.g. 0x20 for " ").
Sorry for having submitted problematic code.


```js
import { run, bench, boxplot } from "mitata";

const PAD = " \n".repeat(16777216)
const PAD2 = " \n\t".repeat(1024)
const CH = "abc".repeat(16777216)
const DATA = `${PAD2}${CH}${PAD}${CH}${PAD2}`

export function useIfFn(str) {
    let start = 0;
    for(; start < str.length; start++) {
        if (!isSpace(str[start])) {
            break;
        }
    }
    let end = str.length - 1;
    for(; end >= start; end--) {
        if (!isSpace(str[end])) {
            break;
        }
    }
    return str.slice(start, end + 1);

    function isSpace(c) {
        return c === " " || c === "\t" || c === "\n" || c === "\r";
    }
}

export function useIfFnCc(str) {
    let start = 0;
    for(; start < str.length; start++) {
        if (!isSpace(str.charCodeAt(start))) {
            break;
        }
    }
    let end = str.length - 1;
    for(; end >= start; end--) {
        if (!isSpace(str.charCodeAt(end))) {
            break;
        }
    }
    return str.slice(start, end + 1);

    function isSpace(c) {
        return c === 0x20 || c === 0x09 || c === 0x0a || c === 0x0d;
    }
}
export function useRegex(str) {
    return str.replace(/^[ \t\n]+(?![ \t\n])|(?<![ \t\n])[ \t\n]+$/g, "");
}


boxplot(() => {
    bench("useIfFn", () => {
        useIfFn(DATA);
    });
    bench("useRegex", () => {
        useRegex(DATA);
    });
    bench("useIfFnCc", () => {
        useIfFnCc(DATA);
    });
});

await run();
```

```
clk: ~4.33 GHz
cpu: 13th Gen Intel(R) Core(TM) i7-1355U
runtime: node 22.12.0 (x64-win32)

benchmark              avg (min … max) p75   p99    (min … top 1%)
-------------------------------------- -------------------------------
useIfFn                  10.54 µs/iter   9.90 µs █
                 (8.80 µs … 419.80 µs)  37.40 µs █▇▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
useRegex                106.56 ms/iter 107.16 ms       █   ▃
               (101.05 ms … 115.18 ms) 110.98 ms ▆▁▁▁▆▁█▁▁▁█▆▆▁▁▁▁▁▁▆▁
useIfFnCc                 9.94 µs/iter   8.80 µs █
                 (7.10 µs … 200.50 µs)  47.80 µs █▇▆▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

                        ┌                                            ┐
                        ┬
                useIfFn │
                        ┴
                                                                 ╷┌┬ ╷
               useRegex                                          ├┤│─┤
                                                                 ╵└┴ ╵
                        ┬
              useIfFnCc │
                        ┴
                        └                                            ┘
                        7.10 µs           55.49 ms           110.98 ms
```