### PR TITLE
Upgrade 'entities' to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "pretest": "npm run build"
   },
   "dependencies": {
-    "entities": "~3.0.1",
+    "entities": "~7.0.0",
     "mdurl": "~1.0.1",
     "minimist": "~1.2.8"
   },


### PR DESCRIPTION
`entities` v4 [adds ESM support](https://github.com/fb55/entities/issues/500#issuecomment-1086363075). I don't know a lot about JS modules, but this upgrade allows me to use `commonmark` whereas before I could not :) I also don't know anything about what else `entities` has changed in the past four major versions, but the tests here still pass.